### PR TITLE
Should check for NULL before calling the callback

### DIFF
--- a/src/heap-profiler.cc
+++ b/src/heap-profiler.cc
@@ -123,6 +123,7 @@ void HeapProfiler::DefineWrapperClass(
 v8::RetainedObjectInfo* HeapProfiler::ExecuteWrapperClassCallback(
     uint16_t class_id, Object** wrapper) {
   if (wrapper_callbacks_.length() <= class_id) return NULL;
+  if (!wrapper_callbacks_[class_id]) return NULL;
   return wrapper_callbacks_[class_id](
       class_id, Utils::ToLocal(Handle<Object>(wrapper)));
 }


### PR DESCRIPTION
Node will define a callback with a large class_id, then the callback
list is filled with NULLs and later leads to crash when generating
snapshot from Webkit (class id = 2).

Fix rogerwang/node-webkit#204.

upstream issue: http://code.google.com/p/v8/issues/detail?id=2430